### PR TITLE
Remove polluting log messages while executing

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -376,8 +376,7 @@ Mexp.lex = function (inp, tokens) {
   }
 
   str.push(closingParObj)
-  console.log(str, inp)
-  //        console.log(str);
+
   return new Mexp(str)
 }
 module.exports = Mexp


### PR DESCRIPTION
Removes unnecessary console log messages, which are polluting the console
when running it inside the browser. This can in long term cause heavy performance issues.