### PR TITLE
lexer: Fix 'i' undefined error in tokenize()

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -159,7 +159,7 @@ Mexp.addToken = function (tokens) {
 function tokenize(string) {
   var nodes = [];
   var length = string.length;
-  for (i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     if (i < length - 1 && string[i] === ' ' && string[i + 1] === ' ') {
       continue
     }


### PR DESCRIPTION
Node 15.2 appears to be fine without the `let`, but this fix allows running this package on Node 8 and possibly other environments.